### PR TITLE
Add testing setup with Vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
-    "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\""
+    "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx,json,css,scss,md}\"",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -78,6 +79,11 @@
     "tailwindcss": "^3.4.13",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.7.0",
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "vitest": "^1.3.1",
+    "jsdom": "^24.0.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.1.6",
+    "@testing-library/user-event": "^14.4.3"
   }
 }

--- a/src/components/__tests__/ColorPicker.test.tsx
+++ b/src/components/__tests__/ColorPicker.test.tsx
@@ -1,0 +1,15 @@
+import { render, fireEvent } from '@testing-library/react';
+import { ColorPicker } from '../ColorPicker';
+import { describe, it, expect, vi } from 'vitest';
+
+describe('ColorPicker', () => {
+  it('calls onColorChange when the color changes', () => {
+    const handleChange = vi.fn();
+    const { container } = render(
+      <ColorPicker className="cls-1" color="#000000" onColorChange={handleChange} />
+    );
+    const input = container.querySelector('input[type="color"]') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '#ffffff' } });
+    expect(handleChange).toHaveBeenCalledWith('cls-1', '#ffffff');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react()],
@@ -8,5 +8,9 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
   },
 });


### PR DESCRIPTION
## Summary
- set up Vitest testing library
- configure Vite for Vitest
- add a simple ColorPicker test

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated testing capabilities for the application.
- **Tests**
  - Introduced a test for the ColorPicker component to verify color change handling.
- **Chores**
  - Updated configuration and dependencies to support testing with Vitest and Testing Library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->