### PR TITLE
Add basic tests for UI components

### DIFF
--- a/src/components/__tests__/Button.test.tsx
+++ b/src/components/__tests__/Button.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { Button } from '../ui/button';
+import { describe, it, expect } from 'vitest';
+
+describe('Button', () => {
+  it('renders a button element', () => {
+    const { container } = render(<Button>Click</Button>);
+    const btn = container.querySelector('button');
+    expect(btn).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/Card.test.tsx
+++ b/src/components/__tests__/Card.test.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import { Card, CardHeader, CardContent } from '../ui/card';
+import { describe, it, expect } from 'vitest';
+
+describe('Card', () => {
+  it('renders children within CardContent', () => {
+    const { getByText } = render(
+      <Card>
+        <CardHeader>Header</CardHeader>
+        <CardContent>Content</CardContent>
+      </Card>
+    );
+    expect(getByText('Header')).toBeTruthy();
+    expect(getByText('Content')).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/Input.test.tsx
+++ b/src/components/__tests__/Input.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { Input } from '../ui/input';
+import { describe, it, expect } from 'vitest';
+
+describe('Input', () => {
+  it('renders an input element', () => {
+    const { container } = render(<Input />);
+    const input = container.querySelector('input');
+    expect(input).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/Map.test.tsx
+++ b/src/components/__tests__/Map.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { Map } from '../Map';
+import { describe, it, expect } from 'vitest';
+
+describe('Map', () => {
+  it('renders an SVG with id "Layer_1"', () => {
+    const { container } = render(<Map />);
+    const svg = container.querySelector('svg#Layer_1');
+    expect(svg).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/Toaster.test.tsx
+++ b/src/components/__tests__/Toaster.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { Toaster } from '../ui/toaster';
+import { describe, it, expect } from 'vitest';
+
+describe('Toaster', () => {
+  it('renders ToastViewport', () => {
+    const { container } = render(<Toaster />);
+    const viewport = container.querySelector('ol');
+    expect(viewport).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add missing tests for Button, Card, Input, Map and Toaster components
- simple render assertions for each component

## Testing
- `npm test --silent`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new tests for Button, Card (including CardHeader and CardContent), Input, Map, and Toaster components to verify their basic rendering and presence of expected elements in the DOM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->